### PR TITLE
Updated package scripts to have pull match other drizzle commands

### DIFF
--- a/packages/data-ops/package.json
+++ b/packages/data-ops/package.json
@@ -25,7 +25,7 @@
     "better-auth:generate": "mkdir -p src/drizzle && npx @better-auth/cli@latest generate --config ./config/auth.ts --output ./src/drizzle/auth-schema.ts",
     "drizzle:generate": "drizzle-kit generate --config drizzle.config.ts",
     "drizzle:migrate": "drizzle-kit migrate --config drizzle.config.ts",
-    "pull": "drizzle-kit pull --config drizzle.config.ts"
+    "drizzle:pull": "drizzle-kit pull --config drizzle.config.ts"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The docs in the Saas kit uses drizzle:pull but the script is just `pnpm run pull`. Using the drizzle prefix seems like the better approach as it aligns with the other commands, so this just adds that